### PR TITLE
Sessions expire too soon

### DIFF
--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -28,8 +28,10 @@ var exports = module.exports = function(settings){
             // response so that the timestamp is up to date, and the session
             // does not expire unless the user is inactive.
 
-            var cookiestr = escape(s.session_key) + '=' +
-                escape(exports.serialize(s.secret, req.session));
+            var cookiestr = escape(s.session_key) + '='
+                + escape(exports.serialize(s.secret, req.session))
+                + '; expires=' + (new Date(new Date().getTime() + (s.timeout))).toUTCString()
+                + '; path=/';
 
             if(Array.isArray(headers)) headers.push(['Set-Cookie', cookiestr]);
             else {


### PR DESCRIPTION
I have my session lifetime set to around 6 months, but the session cookie (_node) expires with the browser session. In looking through the code, no cookie expire time was being set, and the default behavior in this case is to expire with the browser session (when the browser is closed). This change makes the cookie expire at the same time that the session (user's session, not browser session) becomes invalid.

I also noticed that I was getting tons of different cookies because no path was being used when setting the cookies, therefore, if you are at /my/page, the cookie will not be valid when you are at /other/page. So I set the path for the session cookie to "/" at all times. Perhaps you'll want this to be configurable at some point, but for now this should be an improvement.

NOTE: I did not update unit tests and I have only tested this minimally.
