### PR TITLE
Fix tests and don't send cookies unnecessarily

### DIFF
--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -28,24 +28,35 @@ var exports = module.exports = function(settings){
             // response so that the timestamp is up to date, and the session
             // does not expire unless the user is inactive.
 
-            var cookiestr = escape(s.session_key) + '='
-                + escape(exports.serialize(s.secret, req.session))
-                + '; expires=' + exports.expires(s.timeout)
-                + '; path=/';
-
-            if(Array.isArray(headers)) headers.push(['Set-Cookie', cookiestr]);
-            else {
-                // if a Set-Cookie header already exists, convert headers to
-                // array so we can send multiple Set-Cookie headers.
-                if(headers['Set-Cookie'] !== undefined){
-                    headers = exports.headersToArray(headers);
-                    headers.push(['Set-Cookie', cookiestr]);
-                    args[args.length-1] = headers;
+            var cookiestr;
+            if (req.session === undefined) {
+                if ("cookie" in req.headers) {
+                    cookiestr = escape(s.session_key) + '='
+                        + '; expires=' + exports.expires(0)
+                        + '; path=/';
                 }
-                // if no Set-Cookie header exists, leave the headers as an
-                // object, and add a Set-Cookie property
+            } else {
+                cookiestr = escape(s.session_key) + '='
+                    + escape(exports.serialize(s.secret, req.session))
+                    + '; expires=' + exports.expires(s.timeout)
+                    + '; path=/';
+            }
+            
+            if (cookiestr !== undefined) {
+                if(Array.isArray(headers)) headers.push(['Set-Cookie', cookiestr]);
                 else {
-                    headers['Set-Cookie'] = cookiestr;
+                    // if a Set-Cookie header already exists, convert headers to
+                    // array so we can send multiple Set-Cookie headers.
+                    if(headers['Set-Cookie'] !== undefined){
+                        headers = exports.headersToArray(headers);
+                        headers.push(['Set-Cookie', cookiestr]);
+                        args[args.length-1] = headers;
+                    }
+                    // if no Set-Cookie header exists, leave the headers as an
+                    // object, and add a Set-Cookie property
+                    else {
+                        headers['Set-Cookie'] = cookiestr;
+                    }
                 }
             }
 
@@ -179,7 +190,7 @@ exports.readSession = function(key, secret, timeout, req){
     if(cookies[key]){
         return exports.deserialize(secret, timeout, cookies[key]);
     }
-    return {};
+    return undefined;
 };
 
 


### PR DESCRIPTION
1) I don't have much experience with git submodules, but I think the nodetest submodule needs updating for the latest tests that you have checked in -- so far as I can tell, the currently referenced version doesn't have test.equal.

2) I've modified the code so that, if the session is undefined, no cookie is sent (and the cookie is cleared if it is already set). A little more code, but nicer to the user in my opinion.
