### PR TITLE
Don't throw on invalid cookies

### DIFF
--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -97,10 +97,10 @@ function extend(obj) {
 
 exports.deserialize = function(secret, timeout, str){
     // Parses a secure cookie string, returning the object stored within it.
-    // Throws an exception if the secure cookie string does not validate.
+    // Ignores cookie if the secure cookie string does not validate.
 
     if(!exports.valid(secret, timeout, str)){
-        throw new Error('invalid cookie');
+        return undefined;
     }
     var data = exports.decrypt(secret, exports.split(str).data_blob);
     return JSON.parse(data);


### PR DESCRIPTION
Since cookies are user input, we shouldn't throw an exception if the cookie does not pass our tests.
Imho ignoring it is sufficient.

Maybe we could emit an event for debugging purposes, but certainly not an error. 
