### PR TITLE
client should be able to specify cookie path in settings

### DIFF
--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -1,16 +1,26 @@
 var crypto = require('crypto');
+var url = require('url');
 
 var exports = module.exports = function(settings){
 
     var default_settings = {
         // don't set a default cookie secret, must be explicitly defined
         session_key: '_node',
-        timeout: 1000 * 60 * 60 * 24 // 24 hours
+        timeout: 1000 * 60 * 60 * 24, // 24 hours
+        path: '/'
     };
     var s = extend(default_settings, settings);
     if(!s.secret) throw new Error('No secret set in cookie-session settings');
 
+    if(typeof s.path !== 'string' || s.path.indexOf('/') != 0)
+        throw new Error('invalid cookie path, must start with "/"');
+
     return function(req, res, next){
+        // if the request is not under the specified path, do nothing.
+        if (url.parse(req.url).pathname.indexOf(s.path) != 0) {
+            next();
+            return;
+        }
 
         // Read session data from a request and store it in req.session
         req.session = exports.readSession(
@@ -39,13 +49,13 @@ var exports = module.exports = function(settings){
                 if ("cookie" in req.headers) {
                     cookiestr = escape(s.session_key) + '='
                         + '; expires=' + exports.expires(0)
-                        + '; path=/';
+                        + '; path=' + s.path;
                 }
             } else {
                 cookiestr = escape(s.session_key) + '='
                     + escape(exports.serialize(s.secret, req.session))
                     + '; expires=' + exports.expires(s.timeout)
-                    + '; path=/';
+                    + '; path=' + s.path;
             }
             
             if (cookiestr !== undefined) {


### PR DESCRIPTION
allow the client of the module to specify the cookie path, useful to reduce network overhead and to limit the transmission of the cookie
