### PR TITLE
Added protection against XSS cookie-theft attacks

### DIFF
--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -39,13 +39,13 @@ var exports = module.exports = function(settings){
                 if ("cookie" in req.headers) {
                     cookiestr = escape(s.session_key) + '='
                         + '; expires=' + exports.expires(0)
-                        + '; path=/';
+                        + '; path=/; HttpOnly';
                 }
             } else {
                 cookiestr = escape(s.session_key) + '='
                     + escape(exports.serialize(s.secret, req.session))
                     + '; expires=' + exports.expires(s.timeout)
-                    + '; path=/';
+                    + '; path=/; HttpOnly';
             }
             
             if (cookiestr !== undefined) {


### PR DESCRIPTION
I've added the HttpOnly attribute to session cookies in order to raise the barrier to XSS cookie theft. It seems like a zero-cost win so I though I'd share.

It's still a draft spec but already has significant browser support. Not sure of the exact status but the 2008 state is described on coding horror below:

http://tools.ietf.org/html/draft-ietf-httpstate-cookie-21
http://www.codinghorror.com/blog/2008/08/protecting-your-cookies-httponly.html
