### PR TITLE
Session Tuning

### DIFF
--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -19,8 +19,13 @@ exports = module.exports = function(settings){
     var default_settings = {
         // don't set a default cookie secret, must be explicitly defined
         session_key: '_node',
-        timeout: 1000 * 60 * 60 * 24, // 24 hours
-        path: '/'
+        timeout: 60 * 60 * 24, // 24 hours in seconds
+        path: '/',
+        domain: null,
+        secure: false,
+        useMaxAge: true,
+        useExpires: true,
+        useHttpOnly: true
     };
     var s = extend(default_settings, settings);
     if(!s.secret) throw new Error('No secret set in cookie-session settings');
@@ -61,19 +66,22 @@ exports = module.exports = function(settings){
             var cookiestr;
             if (req.session === undefined) {
                 if ("cookie" in req.headers) {
-                    cookiestr = escape(s.session_key) + '='
-                        + '; expires=' + exports.expires(0)
-                        + '; path=' + s.path + '; HttpOnly';
+                    cookiestr = escape(s.session_key) + '=';
+                    s.timeout = 0;
                 }
             } else {
-                cookiestr = escape(s.session_key) + '='
-                    + escape(exports.serialize(s.secret, req.session))
-                    + '; expires=' + exports.expires(s.timeout)
-                    + '; path=' + s.path + '; HttpOnly';
+                cookiestr = escape(s.session_key) + '=' + escape(exports.serialize(s.secret, req.session));
             }
 
+            if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout * 1000); // In milliseconds
+            if (s.useMaxAge)   cookiestr += '; max-age=' + s.timeout; // In seconds
+            if (s.path)        cookiestr += '; path=' + s.path;
+            if (s.domain)      cookiestr += '; domain=' + s.domain;
+            if (s.secure)      cookiestr += '; secure';
+            if (s.useHttpOnly) cookiestr += '; HttpOnly';
+
             if (cookiestr !== undefined) {
-                if(Array.isArray(headers)) { 
+                if(Array.isArray(headers)) {
                     headers.push(['Set-Cookie', cookiestr]);
                 } else {
                     // if a Set-Cookie header already exists, convert headers to

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -74,7 +74,7 @@ exports = module.exports = function(settings){
             }
 
             if (cookiestr !== undefined) {
-                if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout * 1000); // In milliseconds
+                if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout);
                 if (s.useMaxAge)   cookiestr += '; max-age=' + s.timeout; // In seconds
                 if (s.path)        cookiestr += '; path=' + s.path;
                 if (s.domain)      cookiestr += '; domain=' + s.domain;
@@ -223,7 +223,8 @@ exports.readSession = function(key, secret, timeout, req){
     return undefined;
 };
 
-
+// Generates an expires date
+// @params timeout the time in seconds before the cookie expires
 exports.expires = function(timeout){
-  return new Date(new Date().getTime() + (timeout)).toUTCString();
+  return new Date(new Date().getTime() + (timeout * 1000)).toUTCString();
 };

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -121,7 +121,7 @@ exports.deserialize = function(secret, timeout, str){
     // Parses a secure cookie string, returning the object stored within it.
     // Throws an exception if the secure cookie string does not validate.
 
-    if(!exports.valid(secret, timeout, str)){
+    if(!exports.valid(secret, timeout, str)) {
         throw new Error('invalid cookie');
     }
     var data = exports.decrypt(secret, exports.split(str).data_blob);
@@ -168,6 +168,7 @@ exports.valid = function(secret, timeout, str){
     var hmac_sig = exports.hmac_signature(
         secret, parts.timestamp, parts.data_blob
     );
+
     return (
         parts.hmac_signature === hmac_sig &&
         parts.timestamp + timeout > new Date().getTime()

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -170,7 +170,7 @@ exports.valid = function(secret, timeout, str){
     );
     return (
         parts.hmac_signature === hmac_sig &&
-        parts.timestamp + timeout > new Date().getTime()
+        parts.timestamp + (timeout * 1000) > new Date().getTime()
     );
 };
 

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -1,7 +1,20 @@
+/*globals escape unescape */
+
 var crypto = require('crypto');
 var url = require('url');
 
-var exports = module.exports = function(settings){
+
+// Extend a given object with all the properties in passed-in object(s).
+// From underscore.js (http://documentcloud.github.com/underscore/)
+function extend(obj) {
+    Array.prototype.slice.call(arguments).forEach(function(source) {
+      for (var prop in source) obj[prop] = source[prop];
+    });
+    return obj;
+}
+
+var exports;
+exports = module.exports = function(settings){
 
     var default_settings = {
         // don't set a default cookie secret, must be explicitly defined
@@ -12,12 +25,13 @@ var exports = module.exports = function(settings){
     var s = extend(default_settings, settings);
     if(!s.secret) throw new Error('No secret set in cookie-session settings');
 
-    if(typeof s.path !== 'string' || s.path.indexOf('/') != 0)
+    if(typeof s.path !== 'string' || s.path.indexOf('/') !== 0) {
         throw new Error('invalid cookie path, must start with "/"');
+    }
 
     return function(req, res, next){
         // if the request is not under the specified path, do nothing.
-        if (url.parse(req.url).pathname.indexOf(s.path) != 0) {
+        if (url.parse(req.url).pathname.indexOf(s.path) !== 0) {
             next();
             return;
         }
@@ -57,19 +71,19 @@ var exports = module.exports = function(settings){
                     + '; expires=' + exports.expires(s.timeout)
                     + '; path=' + s.path + '; HttpOnly';
             }
-            
+
             if (cookiestr !== undefined) {
-                if(Array.isArray(headers)) headers.push(['Set-Cookie', cookiestr]);
-                else {
+                if(Array.isArray(headers)) { 
+                    headers.push(['Set-Cookie', cookiestr]);
+                } else {
                     // if a Set-Cookie header already exists, convert headers to
                     // array so we can send multiple Set-Cookie headers.
-                    if(headers['Set-Cookie'] !== undefined){
+                    if (headers['Set-Cookie'] !== undefined) {
                         headers = exports.headersToArray(headers);
                         headers.push(['Set-Cookie', cookiestr]);
-                    }
-                    // if no Set-Cookie header exists, leave the headers as an
-                    // object, and add a Set-Cookie property
-                    else {
+                    } else {
+                        // if no Set-Cookie header exists, leave the headers as an
+                        // object, and add a Set-Cookie property
                         headers['Set-Cookie'] = cookiestr;
                     }
                 }
@@ -81,7 +95,7 @@ var exports = module.exports = function(settings){
             }
             // call the original writeHead on the request
             return _writeHead.apply(res, args);
-        }
+        };
         next();
 
     };
@@ -93,16 +107,6 @@ exports.headersToArray = function(headers){
         arr.push([k, headers[k]]);
         return arr;
     }, []);
-};
-
-
-// Extend a given object with all the properties in passed-in object(s).
-// From underscore.js (http://documentcloud.github.com/underscore/)
-function extend(obj) {
-    Array.prototype.slice.call(arguments).forEach(function(source) {
-      for (var prop in source) obj[prop] = source[prop];
-    });
-    return obj;
 };
 
 exports.deserialize = function(secret, timeout, str){
@@ -121,7 +125,7 @@ exports.serialize = function(secret, data){
 
     var data_str = JSON.stringify(data);
     var data_enc = exports.encrypt(secret, data_str);
-    var timestamp = (new Date()).getTime();
+    var timestamp = new Date().getTime();
     var hmac_sig = exports.hmac_signature(secret, timestamp, data_enc);
     var result = hmac_sig + timestamp + data_enc;
     if(!exports.checkLength(result)){
@@ -184,21 +188,20 @@ exports.readCookies = function(req){
     // will already contain the parsed cookies
     if (req.cookies) {
         return req.cookies;
+    } else {
+    // Extracts the cookies from a request object.
+    var cookie = req.headers.cookie;
+    if(!cookie){
+        return {};
     }
-    else {
-        // Extracts the cookies from a request object.
-        var cookie = req.headers.cookie;
-        if(!cookie){
-            return {};
-        }
-        var parts = cookie.split(/\s*;\s*/g).map(function(x){
-            return x.split('=');
-        });
-        return parts.reduce(function(a, x){
-            a[unescape(x[0])] = unescape(x[1]);
-            return a;
-        }, {});
-    }
+    var parts = cookie.split(/\s*;\s*/g).map(function(x){
+        return x.split('=');
+    });
+    return parts.reduce(function(a, x){
+        a[unescape(x[0])] = unescape(x[1]);
+        return a;
+    }, {});
+  }
 };
 
 exports.readSession = function(key, secret, timeout, req){
@@ -214,5 +217,5 @@ exports.readSession = function(key, secret, timeout, req){
 
 
 exports.expires = function(timeout){
-    return (new Date(new Date().getTime() + (timeout))).toUTCString();
+  return new Date(new Date().getTime() + (timeout)).toUTCString();
 };

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -73,14 +73,14 @@ exports = module.exports = function(settings){
                 cookiestr = escape(s.session_key) + '=' + escape(exports.serialize(s.secret, req.session));
             }
 
-            if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout * 1000); // In milliseconds
-            if (s.useMaxAge)   cookiestr += '; max-age=' + s.timeout; // In seconds
-            if (s.path)        cookiestr += '; path=' + s.path;
-            if (s.domain)      cookiestr += '; domain=' + s.domain;
-            if (s.secure)      cookiestr += '; secure';
-            if (s.useHttpOnly) cookiestr += '; HttpOnly';
-
             if (cookiestr !== undefined) {
+                if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout * 1000); // In milliseconds
+                if (s.useMaxAge)   cookiestr += '; max-age=' + s.timeout; // In seconds
+                if (s.path)        cookiestr += '; path=' + s.path;
+                if (s.domain)      cookiestr += '; domain=' + s.domain;
+                if (s.secure)      cookiestr += '; secure';
+                if (s.useHttpOnly) cookiestr += '; HttpOnly';
+
                 if(Array.isArray(headers)) {
                     headers.push(['Set-Cookie', cookiestr]);
                 } else {

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -19,7 +19,7 @@ exports = module.exports = function(settings){
     var default_settings = {
         // don't set a default cookie secret, must be explicitly defined
         session_key: '_node',
-        timeout: 60 * 60 * 24, // 24 hours in seconds
+        timeout: 60 * 60 * 24 * 1000, // 24 hours in milliseconds
         path: '/',
         domain: null,
         secure: false,
@@ -75,7 +75,7 @@ exports = module.exports = function(settings){
 
             if (cookiestr !== undefined) {
                 if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout);
-                if (s.useMaxAge)   cookiestr += '; max-age=' + s.timeout; // In seconds
+                if (s.useMaxAge)   cookiestr += '; max-age=' + (s.timeout / 1000); // In seconds
                 if (s.path)        cookiestr += '; path=' + s.path;
                 if (s.domain)      cookiestr += '; domain=' + s.domain;
                 if (s.secure)      cookiestr += '; secure';
@@ -170,7 +170,7 @@ exports.valid = function(secret, timeout, str){
     );
     return (
         parts.hmac_signature === hmac_sig &&
-        parts.timestamp + (timeout * 1000) > new Date().getTime()
+        parts.timestamp + timeout > new Date().getTime()
     );
 };
 
@@ -224,7 +224,7 @@ exports.readSession = function(key, secret, timeout, req){
 };
 
 // Generates an expires date
-// @params timeout the time in seconds before the cookie expires
+// @params timeout the time in milliseconds before the cookie expires
 exports.expires = function(timeout){
-  return new Date(new Date().getTime() + (timeout * 1000)).toUTCString();
+  return new Date(new Date().getTime() + timeout).toUTCString();
 };

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ require.paths.push(__dirname + '/deps');
 require.paths.push(__dirname + '/lib');
 
 try {
-    var testrunner = require('nodeunit').testrunner;
+    var testrunner = require('nodeunit').reporters.default;
 }
 catch(e) {
     var sys = require('sys');

--- a/test/test-cookie-sessions.js
+++ b/test/test-cookie-sessions.js
@@ -319,14 +319,14 @@ exports['onRequest'] = function(test){
     var s = {
         session_key:'_node',
         secret: 'secret',
-        timeout: 86400
+        timeout: 86400000
     };
     var req = {url: '/'};
 
     sessions.readSession = function(key, secret, timeout, req){
         test.equals(key, '_node', 'readSession called with session key');
         test.equals(secret, 'secret', 'readSession called with secret');
-        test.equals(timeout, 86400, 'readSession called with timeout');
+        test.equals(timeout, 86400000, 'readSession called with timeout');
         return 'testsession';
     };
     var next = function(){
@@ -348,7 +348,7 @@ exports['writeHead'] = function(test){
     var s = {
         session_key:'_node',
         secret: 'secret',
-        timeout: 86400
+        timeout: 86400000
     };
     var req = {headers: {cookie: "_node="}, url: '/'};
     var res = {
@@ -395,7 +395,7 @@ exports['writeHead doesnt write cookie if none exists and session is undefined']
     var s = {
         session_key:'_node',
         secret: 'secret',
-        timeout: 86400
+        timeout: 86400000
     };
     var req = {headers: {}, url: '/'};
     var res = {
@@ -420,7 +420,7 @@ exports['writeHead writes empty cookie with immediate expiration if session is u
     var s = {
         session_key:'_node',
         secret: 'secret',
-        timeout: 86400
+        timeout: 86400000
     };
     var req = {headers: {cookie: "_node=Blah"}, url: '/'};
     var res = {
@@ -490,7 +490,7 @@ exports['set multiple cookies'] = function(test){
 
     var _expires = sessions.expires;
     sessions.expires = function(timeout){
-        test.equals(timeout, 12345);
+        test.equals(timeout, 12345000);
         return 'expiry_date';
     };
 
@@ -510,7 +510,7 @@ exports['set multiple cookies'] = function(test){
         test.done();
     }};
 
-    sessions({secret: 'secret', timeout: 12345})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, {
             'other_header': 'val',
@@ -528,7 +528,7 @@ exports['set single cookie'] = function(test){
 
     var _expires = sessions.expires;
     sessions.expires = function(timeout){
-        test.equals(timeout, 12345);
+        test.equals(timeout, 12345000);
         return 'expiry_date';
     };
 
@@ -546,7 +546,7 @@ exports['set single cookie'] = function(test){
         sessions.expires = _expires;
         test.done();
     }};
-    sessions({secret: 'secret', timeout: 12345})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, {'other_header': 'val'});
     });
@@ -561,7 +561,7 @@ exports['handle headers as array'] = function(test){
 
     var _expires = sessions.expires;
     sessions.expires = function(timeout){
-        test.equals(timeout, 12345);
+        test.equals(timeout, 12345000);
         return 'expiry_date';
     };
 
@@ -579,7 +579,7 @@ exports['handle headers as array'] = function(test){
         sessions.serialize = _serialize;
         test.done();
     }};
-    sessions({secret: 'secret', timeout: 12345})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, [['header1', 'val1'],['header2', 'val2']]);
     });
@@ -607,7 +607,7 @@ exports['send cookies even if there are no headers'] = function (test) {
             test.done();
         }
     };
-    sessions({secret: 'secret', timeout: 12345})(req, res, function () {
+    sessions({secret: 'secret', timeout: 12345000})(req, res, function () {
         req.session = {test: 'test'};
         res.writeHead(200);
     });
@@ -624,7 +624,7 @@ exports['send cookies when no headers but reason_phrase'] = function (test) {
             test.done();
         }
     };
-    sessions({secret: 'secret', timeout: 12345})(req, res, function () {
+    sessions({secret: 'secret', timeout: 12345000})(req, res, function () {
         req.session = {test: 'test'};
         res.writeHead(200, 'reason');
     });
@@ -642,7 +642,7 @@ exports['custom path'] = function (test) {
     };
     sessions({
         secret: 'secret',
-        timeout: 12345,
+        timeout: 12345000,
         path: '/test/path'
     })(req, res, function () {
         req.session = {test: 'test'};
@@ -662,7 +662,7 @@ exports['don\'t set cookie if incorrect path'] = function (test) {
     };
     sessions({
         secret: 'secret',
-        timeout: 12345,
+        timeout: 12345000,
         path: '/test/path'
     })(req, res, function () {
         req.session = {test: 'test'};
@@ -727,7 +727,7 @@ exports['useExpires: false'] = function(test){
         sessions.serialize = _serialize;
         test.done();
     }};
-    sessions({secret: 'secret', timeout: 12345, useExpires: false})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000, useExpires: false})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, {'other_header': 'val'});
     });
@@ -742,7 +742,7 @@ exports['useMaxAge: false'] = function(test){
 
     var _expires = sessions.expires;
     sessions.expires = function(timeout){
-        test.equals(timeout, 12345);
+        test.equals(timeout, 12345000);
         return 'expiry_date';
     };
     var req = {headers: {cookie:''}, url: '/'};
@@ -758,7 +758,7 @@ exports['useMaxAge: false'] = function(test){
         sessions.expires = _expires;
         test.done();
     }};
-    sessions({secret: 'secret', timeout: 12345, useMaxAge: false})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000, useMaxAge: false})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, {'other_header': 'val'});
     });
@@ -773,7 +773,7 @@ exports['useHttpOnly: false'] = function(test){
 
     var _expires = sessions.expires;
     sessions.expires = function(timeout){
-        test.equals(timeout, 12345);
+        test.equals(timeout, 12345000);
         return 'expiry_date';
     };
     var req = {headers: {cookie:''}, url: '/'};
@@ -790,7 +790,7 @@ exports['useHttpOnly: false'] = function(test){
         sessions.expires = _expires;
         test.done();
     }};
-    sessions({secret: 'secret', timeout: 12345, useHttpOnly: false})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000, useHttpOnly: false})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, {'other_header': 'val'});
     });


### PR DESCRIPTION
Switched branches.  Here is the original message:

I’ve been using cookie-sessions for a while and thought I’d push back the additions I made. I tried to make it into nice clean commits, but had to make a few corrections along the way. The key changes are that you can now set the 'domain' and make the cookie 'secure' as well as that 'max-age' will be sent if useMaxAge is true (default). Just to be complete, I also made it so that you can also selectively turn off setting 'expires' and 'HttpOnly' with useExpires:false and useHttpOnly: false, but the defaults are that they’re true so it shouldn’t change any existing uses of cookie-sessions.
