### PR TITLE
Dont overwrite Headers written by response.setHeader

### DIFF
--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -79,7 +79,10 @@ exports.deserialize = function(secret, timeout, str){
         throw new Error('invalid cookie');
     }
     var data = exports.decrypt(secret, exports.split(str).data_blob);
-    return JSON.parse(data);
+    var timestamp = exports.split(str).timestamp;
+    var json = JSON.parse(data);
+    json.timestamp = timestamp;
+    return json;
 };
 
 exports.serialize = function(secret, data){

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -26,90 +26,34 @@ var exports = module.exports = function(settings){
         req.session = exports.readSession(
             s.session_key, s.secret, s.timeout, req);
 
-        // proxy writeHead to add cookie to response
-        var _writeHead = res.writeHead;
-        res.writeHead = function(statusCode){
+        var writeHead = res.writeHead;
+        res.writeHead = function(status, headers){
+          // TODO: In the old version a session-cookie will be set on every request.
+          //       It has to be checked whether this is useful or not.
+          if (req.session) {
+            res.setHeader('Set-Cookie', buildCookieStr(s, req.session));
+          }
 
-            var reasonPhrase, headers;
-            if (typeof arguments[1] === 'string') {
-                reasonPhrase = arguments[1];
-                headers = arguments[2] || {};
-            }
-            else {
-                headers = arguments[1] || {};
-            }
+          res.writeHead = writeHead;
+          return res.writeHead(status, headers);
+        };
 
-            // Add a Set-Cookie header to all responses with the session data
-            // and the current timestamp. The cookie needs to be set on every
-            // response so that the timestamp is up to date, and the session
-            // does not expire unless the user is inactive.
+        // TODO: This is from connect/session, which works fine with other SessionStores.
+        //       It has to be checked whether this us useful in out circumstance.
+        var end = res.end;
+        res.end = function(data, encoding) {
+          res.end = end;
+          // HACK: ensure Set-Cookie for implicit writeHead()
+          if (req.session && !res._header) {
+            res._implicitHeader();
+          }
+          res.end(data, encoding);
+        };
 
-            var cookiestr;
-            if (req.session === undefined) {
-                if ("cookie" in req.headers) {
-                    cookiestr = escape(s.session_key) + '='
-                        + '; expires=' + exports.expires(0)
-                        + '; path=' + s.path + '; HttpOnly';
-                }
-            } else {
-                cookiestr = escape(s.session_key) + '='
-                    + escape(exports.serialize(s.secret, req.session))
-                    + '; expires=' + exports.expires(s.timeout)
-                    + '; path=' + s.path + '; HttpOnly';
-            }
-            
-            if (cookiestr !== undefined) {
-                if(Array.isArray(headers)) headers.push(['Set-Cookie', cookiestr]);
-                else {
-                    // if a Set-Cookie header already exists, convert headers to
-                    // array so we can send multiple Set-Cookie headers.
-                    if(headers['Set-Cookie'] !== undefined){
-                        headers = exports.headersToArray(headers);
-                        headers.push(['Set-Cookie', cookiestr]);
-                    }
-                    // Some Headers are written via response.setHeader and will
-                    // be lost, if only explicit setHead-Calls are rewritten
-                    else if (res.getHeader('Set-Cookie') !== undefined) {
-                        setSessionCookieHeader(cookiestr, res);
-                    }
-                    // if no Set-Cookie header exists, leave the headers as an
-                    // object, and add a Set-Cookie property
-                    else {
-                        headers['Set-Cookie'] = cookiestr;
-                    }
-                }
-            }
-
-            var args = [statusCode, reasonPhrase, headers];
-            if (!args[1]) {
-                args.splice(1, 1);
-            }
-            // call the original writeHead on the request
-            return _writeHead.apply(res, args);
-        }
         next();
 
     };
 };
-
-exports.headersToArray = function(headers){
-    if(Array.isArray(headers)) return headers;
-    return Object.keys(headers).reduce(function(arr, k){
-        arr.push([k, headers[k]]);
-        return arr;
-    }, []);
-};
-
-function setSessionCookieHeader(cookiestr, response) {
-    var newCookieHeader, oldCookieHeader;
-    oldCookieHeader = response.getHeader('Set-Cookie');
-    if (Array.isArray(oldCookieHeader)) {
-        newCookieHeader = oldCookieHeader.concat(cookiestr);
-    } else {
-        newCookieHeader = [oldCookieHeader, cookiestr];
-    }
-    response.setHeader('Set-Cookie', newCookieHeader);
-}
 
 // Extend a given object with all the properties in passed-in object(s).
 // From underscore.js (http://documentcloud.github.com/underscore/)
@@ -118,6 +62,13 @@ function extend(obj) {
       for (var prop in source) obj[prop] = source[prop];
     });
     return obj;
+};
+
+function buildCookieStr(settings, session) {
+  return escape(settings.session_key) + '='
+      + escape(exports.serialize(settings.secret, session))
+      + '; expires=' + exports.expires(settings.timeout)
+      + '; path=' + settings.path + '; HttpOnly';
 };
 
 exports.deserialize = function(secret, timeout, str){

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -67,6 +67,11 @@ var exports = module.exports = function(settings){
                         headers = exports.headersToArray(headers);
                         headers.push(['Set-Cookie', cookiestr]);
                     }
+                    // Some Headers are written via response.setHeader and will
+                    // be lost, if only explicit setHead-Calls are rewritten
+                    else if (res.getHeader('Set-Cookie') !== undefined) {
+                        setSessionCookieHeader(cookiestr, res);
+                    }
                     // if no Set-Cookie header exists, leave the headers as an
                     // object, and add a Set-Cookie property
                     else {
@@ -95,6 +100,16 @@ exports.headersToArray = function(headers){
     }, []);
 };
 
+function setSessionCookieHeader(cookiestr, response) {
+    var newCookieHeader, oldCookieHeader;
+    oldCookieHeader = response.getHeader('Set-Cookie');
+    if (Array.isArray(oldCookieHeader)) {
+        newCookieHeader = oldCookieHeader.concat(cookiestr);
+    } else {
+        newCookieHeader = [oldCookieHeader, cookiestr];
+    }
+    response.setHeader('Set-Cookie', newCookieHeader);
+}
 
 // Extend a given object with all the properties in passed-in object(s).
 // From underscore.js (http://documentcloud.github.com/underscore/)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 , "description": "Secure cookie-based session middleware for Connect"
 , "main": "./index"
 , "author": "Original Author: Caolan McMahon"
-, "version": "0.0.3"
+, "version": "0.0.2"
 , "repository" :
   { "type" : "git"
   , "url" : "http://github.com/jenshimmelreich/cookie-sessions.git"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 { "name": "cookie-sessions"
 , "description": "Secure cookie-based session middleware for Connect"
 , "main": "./index"
-, "author": "Caolan McMahon"
-, "version": "0.0.2"
+, "author": "Original Author: Caolan McMahon"
+, "version": "0.0.2.1"
 , "repository" :
   { "type" : "git"
-  , "url" : "http://github.com/caolan/cookie-sessions.git"
+  , "url" : "http://github.com/jenshimmelreich/cookie-sessions.git"
   }
-, "bugs" : { "web" : "http://github.com/caolan/cookie-sessions/issues" }
+, "bugs" : { "web" : "http://github.com/jenshimmelreich/cookie-sessions/issues" }
 , "licenses" :
   [ { "type" : "MIT"
     , "url" : "http://github.com/caolan/cookie-sessions/raw/master/LICENSE"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   { "type" : "git"
   , "url" : "http://github.com/jenshimmelreich/cookie-sessions.git"
   }
-, "bugs" : { "web" : "http://github.com/jenshimmelreich/cookie-sessions/issues" }
+, "bugs" : { "url" : "http://github.com/jenshimmelreich/cookie-sessions/issues" }
 , "licenses" :
   [ { "type" : "MIT"
     , "url" : "http://github.com/caolan/cookie-sessions/raw/master/LICENSE"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 , "description": "Secure cookie-based session middleware for Connect"
 , "main": "./index"
 , "author": "Original Author: Caolan McMahon"
-, "version": "0.0.2"
+, "version": "0.0.3"
 , "repository" :
   { "type" : "git"
   , "url" : "http://github.com/jenshimmelreich/cookie-sessions.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 , "description": "Secure cookie-based session middleware for Connect"
 , "main": "./index"
 , "author": "Original Author: Caolan McMahon"
-, "version": "0.0.2.1"
+, "version": "0.0.2"
 , "repository" :
   { "type" : "git"
   , "url" : "http://github.com/jenshimmelreich/cookie-sessions.git"


### PR DESCRIPTION
The original module modifies response.writeHead to include the cookie-Header. The Headers which are setted by response.setHeader won't be arguments to writeHead. If another session is setted by setHeader, it will be lost. This patch adds the session cookie to other cookies, which would be setted by setHeader.
