### PR TITLE
Minor change in package.json to comply with new npm policies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   { "type" : "git"
   , "url" : "http://github.com/caolan/cookie-sessions.git"
   }
-, "bugs" : { "web" : "http://github.com/caolan/cookie-sessions/issues" }
+, "bugs" : { "url" : "http://github.com/caolan/cookie-sessions/issues" }
 , "licenses" :
   [ { "type" : "MIT"
     , "url" : "http://github.com/caolan/cookie-sessions/raw/master/LICENSE"


### PR DESCRIPTION
Currently, almost all operations with npm produce this error:

```
npm WARN cookie-sessions@0.0.2 package.json: bugs['web'] should probably be bugs['url']
```
