### PR TITLE
Don't break when you change your secret...just forget the session.

### DIFF
--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -110,7 +110,8 @@ exports.deserialize = function(secret, timeout, str){
     // Throws an exception if the secure cookie string does not validate.
 
     if(!exports.valid(secret, timeout, str)){
-        throw new Error('invalid cookie');
+        console.warn('Invalid cookie HMAC. Using empty object.');
+        return {};
     }
     var data = exports.decrypt(secret, exports.split(str).data_blob);
     return JSON.parse(data);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   , "url" : "http://github.com/caolan/cookie-sessions.git"
   }
 , "bugs" : { "url" : "http://github.com/caolan/cookie-sessions/issues" }
+, "devDependencies": { "nodeunit": ">= 0.6.0" }
 , "licenses" :
   [ { "type" : "MIT"
     , "url" : "http://github.com/caolan/cookie-sessions/raw/master/LICENSE"


### PR DESCRIPTION
Simply allow the app to return a blank session when the cookie is invalid.  This is handy when you change your 'secret' string, and ensures that the app doesn't break, leaving your users with the task of deleting their
cookies manually. Instead, it simply forgets everything about their session.
