### PR TITLE
CoffeeScript rewrite + Added an onError setting to the initial call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Cakefile
+++ b/Cakefile
@@ -1,0 +1,16 @@
+# Based on https://github.com/twilson63/express-coffee/blob/master/Cakefile
+
+fs            = require 'fs'
+{print}       = require 'sys'
+{spawn, exec} = require 'child_process'
+
+build = (callback) ->
+  options = ['-c', '-o', 'lib', 'src']
+  coffee = spawn 'coffee', options
+  coffee.stdout.on 'data', (data) -> print data.toString()
+  coffee.stderr.on 'data', (data) -> print data.toString()
+  coffee.on 'exit', (status) -> callback?() if status is 0
+
+task 'build', 'Compile CoffeeScript source files', ->
+  build()
+

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -19,8 +19,13 @@ exports = module.exports = function(settings){
     var default_settings = {
         // don't set a default cookie secret, must be explicitly defined
         session_key: '_node',
-        timeout: 1000 * 60 * 60 * 24, // 24 hours
-        path: '/'
+        timeout: 60 * 60 * 24, // 24 hours in seconds
+        path: '/',
+        domain: null,
+        secure: false,
+        useMaxAge: true,
+        useExpires: true,
+        useHttpOnly: true
     };
     var s = extend(default_settings, settings);
     if(!s.secret) throw new Error('No secret set in cookie-session settings');
@@ -61,19 +66,22 @@ exports = module.exports = function(settings){
             var cookiestr;
             if (req.session === undefined) {
                 if ("cookie" in req.headers) {
-                    cookiestr = escape(s.session_key) + '='
-                        + '; expires=' + exports.expires(0)
-                        + '; path=' + s.path + '; HttpOnly';
+                    cookiestr = escape(s.session_key) + '=';
+                    s.timeout = 0;
                 }
             } else {
-                cookiestr = escape(s.session_key) + '='
-                    + escape(exports.serialize(s.secret, req.session))
-                    + '; expires=' + exports.expires(s.timeout)
-                    + '; path=' + s.path + '; HttpOnly';
+                cookiestr = escape(s.session_key) + '=' + escape(exports.serialize(s.secret, req.session));
             }
 
+            if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout * 1000); // In milliseconds
+            if (s.useMaxAge)   cookiestr += '; max-age=' + s.timeout; // In seconds
+            if (s.path)        cookiestr += '; path=' + s.path;
+            if (s.domain)      cookiestr += '; domain=' + s.domain;
+            if (s.secure)      cookiestr += '; secure';
+            if (s.useHttpOnly) cookiestr += '; HttpOnly';
+
             if (cookiestr !== undefined) {
-                if(Array.isArray(headers)) { 
+                if(Array.isArray(headers)) {
                     headers.push(['Set-Cookie', cookiestr]);
                 } else {
                     // if a Set-Cookie header already exists, convert headers to

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -1,233 +1,186 @@
-/*globals escape unescape */
+(function() {
+  var crypto, exports, url;
+  var __hasProp = Object.prototype.hasOwnProperty, _this = this;
 
-var crypto = require('crypto');
-var url = require('url');
+  crypto = require('crypto');
 
+  url = require('url');
 
-// Extend a given object with all the properties in passed-in object(s).
-// From underscore.js (http://documentcloud.github.com/underscore/)
-function extend(obj) {
-    Array.prototype.slice.call(arguments).forEach(function(source) {
-      for (var prop in source) obj[prop] = source[prop];
-    });
-    return obj;
-}
-
-var exports;
-exports = module.exports = function(settings){
-
-    var default_settings = {
-        // don't set a default cookie secret, must be explicitly defined
-        session_key: '_node',
-        timeout: 60 * 60 * 24 * 1000, // 24 hours in milliseconds
-        path: '/',
-        domain: null,
-        secure: false,
-        useMaxAge: true,
-        useExpires: true,
-        useHttpOnly: true
+  exports = module.exports = function(settings) {
+    var k, s, v;
+    var _this = this;
+    s = {
+      session_key: '_node',
+      timeout: 24 * 60 * 60 * 1000,
+      path: '/',
+      domain: null,
+      secure: false,
+      useMaxAge: true,
+      useExpires: true,
+      useHttpOnly: true
     };
-    var s = extend(default_settings, settings);
-    if(!s.secret) throw new Error('No secret set in cookie-session settings');
-
-    if(typeof s.path !== 'string' || s.path.indexOf('/') !== 0) {
-        throw new Error('invalid cookie path, must start with "/"');
+    for (k in settings) {
+      if (!__hasProp.call(settings, k)) continue;
+      v = settings[k];
+      s[k] = v;
     }
-
-    return function(req, res, next){
-        // if the request is not under the specified path, do nothing.
-        if (url.parse(req.url).pathname.indexOf(s.path) !== 0) {
-            next();
-            return;
+    if (!s.secret) throw new Error('No secret set in cookie-session settings');
+    if ("string" !== typeof s.path || 0 !== s.path.indexOf("/")) {
+      throw new Error('invalid cookie path, must start with "/"');
+    }
+    return function(req, res, next) {
+      var _writeHead;
+      if (0 !== url.parse(req.url).pathname.indexOf(s.path)) return next();
+      req.session = exports.readSession(s.session_key, s.secret, s.timeout, req);
+      _writeHead = res.writeHead;
+      res.writeHead = function(statusCode) {
+        var args, cookiestr, headers, reasonPhrase;
+        reasonPhrase = null;
+        headers = null;
+        if ("string" === typeof arguments[1]) {
+          reasonPhrase = arguments[1];
+          headers = arguments[2] || {};
+        } else {
+          headers = arguments[1] || {};
         }
-
-        // Read session data from a request and store it in req.session
-        req.session = exports.readSession(
-            s.session_key, s.secret, s.timeout, req);
-
-        // proxy writeHead to add cookie to response
-        var _writeHead = res.writeHead;
-        res.writeHead = function(statusCode){
-
-            var reasonPhrase, headers;
-            if (typeof arguments[1] === 'string') {
-                reasonPhrase = arguments[1];
-                headers = arguments[2] || {};
-            }
-            else {
-                headers = arguments[1] || {};
-            }
-
-            // Add a Set-Cookie header to all responses with the session data
-            // and the current timestamp. The cookie needs to be set on every
-            // response so that the timestamp is up to date, and the session
-            // does not expire unless the user is inactive.
-
-            var cookiestr;
-            if (req.session === undefined) {
-                if ("cookie" in req.headers) {
-                    cookiestr = escape(s.session_key) + '=';
-                    s.timeout = 0;
-                }
+        cookiestr = null;
+        if (!req.session) {
+          if ("cookie" in req.headers) {
+            cookiestr = escape(s.session_key) + '=';
+            s.timeout = 0;
+          }
+        } else {
+          cookiestr = escape(s.session_key) + '=' + escape(exports.serialize(s.secret, req.session));
+        }
+        if (cookiestr) {
+          if (s.useExpires) cookiestr += '; expires=' + exports.expires(s.timeout);
+          if (s.useMaxAge) cookiestr += '; max-age=' + (s.timeout / 1000);
+          if (s.path) cookiestr += '; path=' + s.path;
+          if (s.domain) cookiestr += '; domain=' + s.domain;
+          if (s.secure) cookiestr += '; secure';
+          if (s.useHttpOnly) cookiestr += '; HttpOnly';
+          if (Array.isArray(headers)) {
+            headers.push(['Set-Cookie', cookiestr]);
+          } else {
+            if (headers['Set-Cookie']) {
+              headers = exports.headersToArray(headers);
+              headers.push(['Set-Cookie', cookiestr]);
             } else {
-                cookiestr = escape(s.session_key) + '=' + escape(exports.serialize(s.secret, req.session));
+              headers['Set-Cookie'] = cookiestr;
             }
-
-            if (cookiestr !== undefined) {
-                if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout);
-                if (s.useMaxAge)   cookiestr += '; max-age=' + (s.timeout / 1000); // In seconds
-                if (s.path)        cookiestr += '; path=' + s.path;
-                if (s.domain)      cookiestr += '; domain=' + s.domain;
-                if (s.secure)      cookiestr += '; secure';
-                if (s.useHttpOnly) cookiestr += '; HttpOnly';
-
-                if(Array.isArray(headers)) {
-                    headers.push(['Set-Cookie', cookiestr]);
-                } else {
-                    // if a Set-Cookie header already exists, convert headers to
-                    // array so we can send multiple Set-Cookie headers.
-                    if (headers['Set-Cookie'] !== undefined) {
-                        headers = exports.headersToArray(headers);
-                        headers.push(['Set-Cookie', cookiestr]);
-                    } else {
-                        // if no Set-Cookie header exists, leave the headers as an
-                        // object, and add a Set-Cookie property
-                        headers['Set-Cookie'] = cookiestr;
-                    }
-                }
-            }
-
-            var args = [statusCode, reasonPhrase, headers];
-            if (!args[1]) {
-                args.splice(1, 1);
-            }
-            // call the original writeHead on the request
-            return _writeHead.apply(res, args);
-        };
-        next();
-
+          }
+        }
+        args = [statusCode, reasonPhrase, headers];
+        if (!args[1]) args.splice(1, 1);
+        return _writeHead.apply(res, args);
+      };
+      return next();
     };
-};
+  };
 
-exports.headersToArray = function(headers){
-    if(Array.isArray(headers)) return headers;
-    return Object.keys(headers).reduce(function(arr, k){
-        arr.push([k, headers[k]]);
-        return arr;
-    }, []);
-};
+  exports.MAX_LENGTH = 4096;
 
-exports.deserialize = function(secret, timeout, str){
-    // Parses a secure cookie string, returning the object stored within it.
-    // Throws an exception if the secure cookie string does not validate.
-
-    if(!exports.valid(secret, timeout, str)) {
-        var error = new Error('invalid cookie');
-        error.type = 'InvalidCookieError';
-        throw error;
-    }
-    var data = exports.decrypt(secret, exports.split(str).data_blob);
-    return JSON.parse(data);
-};
-
-exports.serialize = function(secret, data){
-    // Turns a JSON-compatibile object literal into a secure cookie string
-
-    var data_str = JSON.stringify(data);
-    var data_enc = exports.encrypt(secret, data_str);
-    var timestamp = new Date().getTime();
-    var hmac_sig = exports.hmac_signature(secret, timestamp, data_enc);
-    var result = hmac_sig + timestamp + data_enc;
-    if(!exports.checkLength(result)){
-        throw new Error('data too long to store in a cookie');
-    }
-    return result;
-};
-
-exports.split = function(str){
-    // Splits a cookie string into hmac signature, timestamp and data blob.
-    return {
-        hmac_signature: str.slice(0,40),
-        timestamp: parseInt(str.slice(40, 53), 10),
-        data_blob: str.slice(53)
-    };
-};
-
-exports.hmac_signature = function(secret, timestamp, data){
-    // Generates a HMAC for the timestamped data, returning the
-    // hex digest for the signature.
-    var hmac = crypto.createHmac('sha1', secret);
-    hmac.update(timestamp + data);
-    return hmac.digest('hex');
-};
-
-exports.valid = function(secret, timeout, str){
-    // Tests the validity of a cookie string. Returns true if the HMAC
-    // signature of the secret, timestamp and data blob matches the HMAC in the
-    // cookie string, and the cookie's age is less than the timeout value.
-
-    var parts = exports.split(str);
-    var hmac_sig = exports.hmac_signature(
-        secret, parts.timestamp, parts.data_blob
-    );
-
-    return (
-        parts.hmac_signature === hmac_sig &&
-        parts.timestamp + timeout > new Date().getTime()
-    );
-};
-
-exports.decrypt = function(secret, str){
-    // Decrypt the aes192 encoded str using secret.
-    var decipher = crypto.createDecipher("aes192", secret);
-    return decipher.update(str, 'hex', 'utf8') + decipher.final('utf8');
-};
-
-exports.encrypt = function(secret, str){
-    // Encrypt the str with aes192 using secret.
-    var cipher = crypto.createCipher("aes192", secret);
-    return cipher.update(str, 'utf8', 'hex') + cipher.final('hex');
-};
-
-exports.checkLength = function(str){
-    // Test if a string is within the maximum length allowed for a cookie.
-    return str.length <= 4096;
-};
-
-exports.readCookies = function(req){
-    // if "cookieDecoder" is in use, then req.cookies
-    // will already contain the parsed cookies
-    if (req.cookies) {
-        return req.cookies;
+  exports.readSession = function(session_key, secret, timeout, req) {
+    var cookies;
+    cookies = exports.readCookies(req);
+    if (session_key in cookies && cookies[session_key]) {
+      return exports.deserialize(secret, timeout, cookies[session_key]);
     } else {
-    // Extracts the cookies from a request object.
-    var cookie = req.headers.cookie;
-    if(!cookie){
-        return {};
+
     }
-    var parts = cookie.split(/\s*;\s*/g).map(function(x){
+  };
+
+  exports.readCookies = function(req) {
+    var cookie, func, parts;
+    if (req.cookies) {
+      return req.cookies;
+    } else {
+      cookie = req.headers.cookie;
+      if (!cookie) return {};
+      parts = cookie.split(/\s*;\s*/g).map(function(x) {
         return x.split('=');
-    });
-    return parts.reduce(function(a, x){
+      });
+      func = function(a, x) {
         a[unescape(x[0])] = unescape(x[1]);
         return a;
-    }, {});
-  }
-};
-
-exports.readSession = function(key, secret, timeout, req){
-    // Reads the session data stored in the cookie named 'key' if it validates,
-    // otherwise returns an empty object.
-
-    var cookies = exports.readCookies(req);
-    if(cookies[key]){
-        return exports.deserialize(secret, timeout, cookies[key]);
+      };
+      return parts.reduce(func, {});
     }
-    return undefined;
-};
+  };
 
-// Generates an expires date
-// @params timeout the time in milliseconds before the cookie expires
-exports.expires = function(timeout){
-  return new Date(new Date().getTime() + timeout).toUTCString();
-};
+  exports.headersToArray = function(headers) {
+    var func;
+    if (Array.isArray(headers)) return headers;
+    func = function(arr, k) {
+      arr.push([k, headers[k]]);
+      return arr;
+    };
+    return Object.keys(headers).reduce(func, []);
+  };
+
+  exports.deserialize = function(secret, timeout, str) {
+    var error;
+    if (!exports.valid(secret, timeout, str)) {
+      error = new Error('invalid cookie');
+      error.type = 'InvalidCookieError';
+      throw error;
+    }
+    return JSON.parse(exports.decrypt(secret, exports.split(str).data_blob));
+  };
+
+  exports.serialize = function(secret, data) {
+    var data_enc, data_str, hmac_sig, result, timestamp;
+    data_str = JSON.stringify(data);
+    data_enc = exports.encrypt(secret, data_str);
+    timestamp = new Date().getTime();
+    hmac_sig = exports.hmac_signature(secret, timestamp, data_enc);
+    result = hmac_sig + timestamp + data_enc;
+    if (!exports.checkLength(result)) {
+      throw new Error('data too long to store in a cookie');
+    }
+    return result;
+  };
+
+  exports.split = function(str) {
+    return {
+      hmac_signature: str.slice(0, 40),
+      timestamp: parseInt(str.slice(40, 53), 10),
+      data_blob: str.slice(53)
+    };
+  };
+
+  exports.hmac_signature = function(secret, timestamp, data) {
+    var hmac;
+    hmac = crypto.createHmac('sha1', secret);
+    hmac.update(timestamp + data);
+    return hmac.digest('hex');
+  };
+
+  exports.valid = function(secret, timeout, str) {
+    var hmac_sig, parts;
+    parts = exports.split(str);
+    hmac_sig = exports.hmac_signature(secret, parts.timestamp, parts.data_blob);
+    return parts.hmac_signature === hmac_sig && new Date().getTime() < (parts.timestamp + timeout);
+  };
+
+  exports.decrypt = function(secret, str) {
+    var decipher;
+    decipher = crypto.createDecipher("aes192", secret);
+    return decipher.update(str, 'hex', 'utf8') + decipher.final('utf8');
+  };
+
+  exports.encrypt = function(secret, str) {
+    var cipher;
+    cipher = crypto.createCipher("aes192", secret);
+    return cipher.update(str, 'utf8', 'hex') + cipher.final('hex');
+  };
+
+  exports.checkLength = function(str) {
+    return str.length <= exports.MAX_LENGTH;
+  };
+
+  exports.expires = function(timeout) {
+    return new Date(new Date().getTime() + timeout).toUTCString();
+  };
+
+}).call(this);

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -74,7 +74,7 @@ exports = module.exports = function(settings){
             }
 
             if (cookiestr !== undefined) {
-                if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout * 1000); // In milliseconds
+                if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout);
                 if (s.useMaxAge)   cookiestr += '; max-age=' + s.timeout; // In seconds
                 if (s.path)        cookiestr += '; path=' + s.path;
                 if (s.domain)      cookiestr += '; domain=' + s.domain;
@@ -223,7 +223,8 @@ exports.readSession = function(key, secret, timeout, req){
     return undefined;
 };
 
-
+// Generates an expires date
+// @params timeout the time in seconds before the cookie expires
 exports.expires = function(timeout){
-  return new Date(new Date().getTime() + (timeout)).toUTCString();
+  return new Date(new Date().getTime() + (timeout * 1000)).toUTCString();
 };

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -1,10 +1,12 @@
 (function() {
-  var crypto, exports, url;
+  var MAX_LENGTH, crypto, exports, url;
   var __hasProp = Object.prototype.hasOwnProperty, _this = this;
 
   crypto = require('crypto');
 
   url = require('url');
+
+  MAX_LENGTH = 4096;
 
   exports = module.exports = function(settings) {
     var k, s, v;
@@ -84,8 +86,6 @@
       return next();
     };
   };
-
-  exports.MAX_LENGTH = 4096;
 
   exports.readSession = function(session_key, secret, timeout, req) {
     var cookies;
@@ -183,7 +183,7 @@
   };
 
   exports.checkLength = function(str) {
-    return str.length <= exports.MAX_LENGTH;
+    return str.length <= MAX_LENGTH;
   };
 
   exports.expires = function(timeout) {

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -122,7 +122,9 @@ exports.deserialize = function(secret, timeout, str){
     // Throws an exception if the secure cookie string does not validate.
 
     if(!exports.valid(secret, timeout, str)) {
-        throw new Error('invalid cookie');
+        var error = new Error('invalid cookie');
+        error.type = 'InvalidCookieError';
+        throw error;
     }
     var data = exports.decrypt(secret, exports.split(str).data_blob);
     return JSON.parse(data);

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -121,7 +121,7 @@ exports.deserialize = function(secret, timeout, str){
     // Parses a secure cookie string, returning the object stored within it.
     // Throws an exception if the secure cookie string does not validate.
 
-    if(!exports.valid(secret, timeout, str)){
+    if(!exports.valid(secret, timeout, str)) {
         throw new Error('invalid cookie');
     }
     var data = exports.decrypt(secret, exports.split(str).data_blob);
@@ -168,6 +168,7 @@ exports.valid = function(secret, timeout, str){
     var hmac_sig = exports.hmac_signature(
         secret, parts.timestamp, parts.data_blob
     );
+
     return (
         parts.hmac_signature === hmac_sig &&
         parts.timestamp + timeout > new Date().getTime()

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -170,7 +170,7 @@ exports.valid = function(secret, timeout, str){
     );
     return (
         parts.hmac_signature === hmac_sig &&
-        parts.timestamp + timeout > new Date().getTime()
+        parts.timestamp + (timeout * 1000) > new Date().getTime()
     );
 };
 

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -1,7 +1,20 @@
+/*globals escape unescape */
+
 var crypto = require('crypto');
 var url = require('url');
 
-var exports = module.exports = function(settings){
+
+// Extend a given object with all the properties in passed-in object(s).
+// From underscore.js (http://documentcloud.github.com/underscore/)
+function extend(obj) {
+    Array.prototype.slice.call(arguments).forEach(function(source) {
+      for (var prop in source) obj[prop] = source[prop];
+    });
+    return obj;
+}
+
+var exports;
+exports = module.exports = function(settings){
 
     var default_settings = {
         // don't set a default cookie secret, must be explicitly defined
@@ -12,12 +25,13 @@ var exports = module.exports = function(settings){
     var s = extend(default_settings, settings);
     if(!s.secret) throw new Error('No secret set in cookie-session settings');
 
-    if(typeof s.path !== 'string' || s.path.indexOf('/') != 0)
+    if(typeof s.path !== 'string' || s.path.indexOf('/') !== 0) {
         throw new Error('invalid cookie path, must start with "/"');
+    }
 
     return function(req, res, next){
         // if the request is not under the specified path, do nothing.
-        if (url.parse(req.url).pathname.indexOf(s.path) != 0) {
+        if (url.parse(req.url).pathname.indexOf(s.path) !== 0) {
             next();
             return;
         }
@@ -57,19 +71,19 @@ var exports = module.exports = function(settings){
                     + '; expires=' + exports.expires(s.timeout)
                     + '; path=' + s.path + '; HttpOnly';
             }
-            
+
             if (cookiestr !== undefined) {
-                if(Array.isArray(headers)) headers.push(['Set-Cookie', cookiestr]);
-                else {
+                if(Array.isArray(headers)) { 
+                    headers.push(['Set-Cookie', cookiestr]);
+                } else {
                     // if a Set-Cookie header already exists, convert headers to
                     // array so we can send multiple Set-Cookie headers.
-                    if(headers['Set-Cookie'] !== undefined){
+                    if (headers['Set-Cookie'] !== undefined) {
                         headers = exports.headersToArray(headers);
                         headers.push(['Set-Cookie', cookiestr]);
-                    }
-                    // if no Set-Cookie header exists, leave the headers as an
-                    // object, and add a Set-Cookie property
-                    else {
+                    } else {
+                        // if no Set-Cookie header exists, leave the headers as an
+                        // object, and add a Set-Cookie property
                         headers['Set-Cookie'] = cookiestr;
                     }
                 }
@@ -81,7 +95,7 @@ var exports = module.exports = function(settings){
             }
             // call the original writeHead on the request
             return _writeHead.apply(res, args);
-        }
+        };
         next();
 
     };
@@ -93,16 +107,6 @@ exports.headersToArray = function(headers){
         arr.push([k, headers[k]]);
         return arr;
     }, []);
-};
-
-
-// Extend a given object with all the properties in passed-in object(s).
-// From underscore.js (http://documentcloud.github.com/underscore/)
-function extend(obj) {
-    Array.prototype.slice.call(arguments).forEach(function(source) {
-      for (var prop in source) obj[prop] = source[prop];
-    });
-    return obj;
 };
 
 exports.deserialize = function(secret, timeout, str){
@@ -121,7 +125,7 @@ exports.serialize = function(secret, data){
 
     var data_str = JSON.stringify(data);
     var data_enc = exports.encrypt(secret, data_str);
-    var timestamp = (new Date()).getTime();
+    var timestamp = new Date().getTime();
     var hmac_sig = exports.hmac_signature(secret, timestamp, data_enc);
     var result = hmac_sig + timestamp + data_enc;
     if(!exports.checkLength(result)){
@@ -184,21 +188,20 @@ exports.readCookies = function(req){
     // will already contain the parsed cookies
     if (req.cookies) {
         return req.cookies;
+    } else {
+    // Extracts the cookies from a request object.
+    var cookie = req.headers.cookie;
+    if(!cookie){
+        return {};
     }
-    else {
-        // Extracts the cookies from a request object.
-        var cookie = req.headers.cookie;
-        if(!cookie){
-            return {};
-        }
-        var parts = cookie.split(/\s*;\s*/g).map(function(x){
-            return x.split('=');
-        });
-        return parts.reduce(function(a, x){
-            a[unescape(x[0])] = unescape(x[1]);
-            return a;
-        }, {});
-    }
+    var parts = cookie.split(/\s*;\s*/g).map(function(x){
+        return x.split('=');
+    });
+    return parts.reduce(function(a, x){
+        a[unescape(x[0])] = unescape(x[1]);
+        return a;
+    }, {});
+  }
 };
 
 exports.readSession = function(key, secret, timeout, req){
@@ -214,5 +217,5 @@ exports.readSession = function(key, secret, timeout, req){
 
 
 exports.expires = function(timeout){
-    return (new Date(new Date().getTime() + (timeout))).toUTCString();
+  return new Date(new Date().getTime() + (timeout)).toUTCString();
 };

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -73,14 +73,14 @@ exports = module.exports = function(settings){
                 cookiestr = escape(s.session_key) + '=' + escape(exports.serialize(s.secret, req.session));
             }
 
-            if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout * 1000); // In milliseconds
-            if (s.useMaxAge)   cookiestr += '; max-age=' + s.timeout; // In seconds
-            if (s.path)        cookiestr += '; path=' + s.path;
-            if (s.domain)      cookiestr += '; domain=' + s.domain;
-            if (s.secure)      cookiestr += '; secure';
-            if (s.useHttpOnly) cookiestr += '; HttpOnly';
-
             if (cookiestr !== undefined) {
+                if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout * 1000); // In milliseconds
+                if (s.useMaxAge)   cookiestr += '; max-age=' + s.timeout; // In seconds
+                if (s.path)        cookiestr += '; path=' + s.path;
+                if (s.domain)      cookiestr += '; domain=' + s.domain;
+                if (s.secure)      cookiestr += '; secure';
+                if (s.useHttpOnly) cookiestr += '; HttpOnly';
+
                 if(Array.isArray(headers)) {
                     headers.push(['Set-Cookie', cookiestr]);
                 } else {

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -19,7 +19,7 @@ exports = module.exports = function(settings){
     var default_settings = {
         // don't set a default cookie secret, must be explicitly defined
         session_key: '_node',
-        timeout: 60 * 60 * 24, // 24 hours in seconds
+        timeout: 60 * 60 * 24 * 1000, // 24 hours in milliseconds
         path: '/',
         domain: null,
         secure: false,
@@ -75,7 +75,7 @@ exports = module.exports = function(settings){
 
             if (cookiestr !== undefined) {
                 if (s.useExpires)  cookiestr += '; expires=' + exports.expires(s.timeout);
-                if (s.useMaxAge)   cookiestr += '; max-age=' + s.timeout; // In seconds
+                if (s.useMaxAge)   cookiestr += '; max-age=' + (s.timeout / 1000); // In seconds
                 if (s.path)        cookiestr += '; path=' + s.path;
                 if (s.domain)      cookiestr += '; domain=' + s.domain;
                 if (s.secure)      cookiestr += '; secure';
@@ -170,7 +170,7 @@ exports.valid = function(secret, timeout, str){
     );
     return (
         parts.hmac_signature === hmac_sig &&
-        parts.timestamp + (timeout * 1000) > new Date().getTime()
+        parts.timestamp + timeout > new Date().getTime()
     );
 };
 
@@ -224,7 +224,7 @@ exports.readSession = function(key, secret, timeout, req){
 };
 
 // Generates an expires date
-// @params timeout the time in seconds before the cookie expires
+// @params timeout the time in milliseconds before the cookie expires
 exports.expires = function(timeout){
-  return new Date(new Date().getTime() + (timeout * 1000)).toUTCString();
+  return new Date(new Date().getTime() + timeout).toUTCString();
 };

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -1,6 +1,6 @@
 (function() {
   var MAX_LENGTH, crypto, exports, url;
-  var __hasProp = Object.prototype.hasOwnProperty, _this = this;
+  var __hasProp = Object.prototype.hasOwnProperty;
 
   crypto = require('crypto');
 
@@ -10,7 +10,6 @@
 
   exports = module.exports = function(settings) {
     var k, s, v;
-    var _this = this;
     s = {
       session_key: '_node',
       timeout: 24 * 60 * 60 * 1000,
@@ -36,6 +35,7 @@
     }
     return function(req, res, next) {
       var _writeHead;
+      var _this = this;
       if (0 !== url.parse(req.url).pathname.indexOf(s.path)) return next();
       req.session = exports.readSession(s.session_key, s.secret, s.timeout, req);
       _writeHead = res.writeHead;

--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -17,16 +17,20 @@
       secure: false,
       useMaxAge: true,
       useExpires: true,
-      useHttpOnly: true
+      useHttpOnly: true,
+      onError: null
     };
     for (k in settings) {
       if (!__hasProp.call(settings, k)) continue;
       v = settings[k];
       s[k] = v;
     }
-    if (!s.secret) throw new Error('No secret set in cookie-session settings');
+    if ("function" === typeof s.onError) exports.Events.onError = s.onError;
+    if (!s.secret) {
+      return exports.Events.throwErr('No secret set in cookie-session settings');
+    }
     if ("string" !== typeof s.path || 0 !== s.path.indexOf("/")) {
-      throw new Error('invalid cookie path, must start with "/"');
+      return exports.Events.throwErr('Invalid cookie path, must start with "/"');
     }
     return function(req, res, next) {
       var _writeHead;
@@ -34,7 +38,7 @@
       req.session = exports.readSession(s.session_key, s.secret, s.timeout, req);
       _writeHead = res.writeHead;
       res.writeHead = function(statusCode) {
-        var args, cookiestr, headers, reasonPhrase;
+        var args, cookiestr, headers, reasonPhrase, serializedData;
         reasonPhrase = null;
         headers = null;
         if ("string" === typeof arguments[1]) {
@@ -50,7 +54,10 @@
             s.timeout = 0;
           }
         } else {
-          cookiestr = escape(s.session_key) + '=' + escape(exports.serialize(s.secret, req.session));
+          serializedData = exports.serialize(s.secret, req.session);
+          if (serializedData) {
+            cookiestr = escape(s.session_key) + '=' + escape(serializedData);
+          }
         }
         if (cookiestr) {
           if (s.useExpires) cookiestr += '; expires=' + exports.expires(s.timeout);
@@ -121,9 +128,9 @@
   exports.deserialize = function(secret, timeout, str) {
     var error;
     if (!exports.valid(secret, timeout, str)) {
-      error = new Error('invalid cookie');
+      error = new Error('Invalid cookie');
       error.type = 'InvalidCookieError';
-      throw error;
+      return exports.Events.throwErr(error);
     }
     return JSON.parse(exports.decrypt(secret, exports.split(str).data_blob));
   };
@@ -136,7 +143,7 @@
     hmac_sig = exports.hmac_signature(secret, timestamp, data_enc);
     result = hmac_sig + timestamp + data_enc;
     if (!exports.checkLength(result)) {
-      throw new Error('data too long to store in a cookie');
+      return exports.Events.throwErr('Data too long to store in a cookie');
     }
     return result;
   };
@@ -182,5 +189,25 @@
   exports.expires = function(timeout) {
     return new Date(new Date().getTime() + timeout).toUTCString();
   };
+
+  exports.Events = (function() {
+
+    function Events() {}
+
+    Events.onError = null;
+
+    Events.throwErr = function(err) {
+      if (typeof err !== "object") err = new Error(err);
+      if (this.onError) {
+        this.onError(err);
+      } else {
+        throw err;
+      }
+      return;
+    };
+
+    return Events;
+
+  })();
 
 }).call(this);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 , "version": "0.0.2"
 , "repository" :
   { "type" : "git"
-  , "url" : "http://github.com/caolan/cookie-sessions.git"
+      , "url" : "http://github.com/caolan/cookie-sessions.git"
   }
 , "bugs" : { "url" : "http://github.com/caolan/cookie-sessions/issues" }
 , "licenses" :
@@ -13,4 +13,7 @@
     , "url" : "http://github.com/caolan/cookie-sessions/raw/master/LICENSE"
     }
   ]
+, "devDependencies": {
+    "coffee-script": "1.1.x"
+  }
 }

--- a/src/cookie-sessions.coffee
+++ b/src/cookie-sessions.coffee
@@ -1,0 +1,224 @@
+crypto = require('crypto')
+url = require('url')
+
+
+exports = module.exports = (settings) ->
+    s =
+        # key name
+        session_key: '_node'
+        # timeout/expiry (24 hours)
+        timeout: 24 * 60 * 60 * 1000
+        # path
+        path: '/'
+        # domain
+        domain: null
+        # https only?
+        secure: false
+        # use 'max-age' ?
+        useMaxAge: true
+        # use 'expires'?
+        useExpires: true
+        # use 'HttpOnly'?
+        useHttpOnly: true
+
+    # extend with passed-in settings
+    for own k,v of settings
+        s[k] = v
+
+    if not s.secret
+        throw new Error 'No secret set in cookie-session settings'
+
+    if "string" isnt typeof s.path or 0 isnt s.path.indexOf("/")
+        throw new Error 'invalid cookie path, must start with "/"'
+
+
+    # Handle a request - the main method!
+    return (req, res, next) =>
+        # if the request is not under the specified path, do nothing.
+        if 0 isnt url.parse(req.url).pathname.indexOf(s.path)
+            return next()
+
+        # Read session data from a request and store it in req.session
+        req.session = exports.readSession(s.session_key, s.secret, s.timeout, req)
+
+        # proxy writeHead to add cookie to response
+        _writeHead = res.writeHead
+        res.writeHead = (statusCode) =>
+
+            reasonPhrase = null
+            headers = null
+            if "string" is typeof arguments[1]
+                reasonPhrase = arguments[1]
+                headers = arguments[2] or {}
+            else
+                headers = arguments[1] or {}
+
+
+            # Add a Set-Cookie header to all responses with the session data
+            # and the current timestamp. The cookie needs to be set on every
+            # response so that the timestamp is up to date, and the session
+            # does not expire unless the user is inactive.
+
+            cookiestr = null
+            # no session yet
+            if not req.session
+                if "cookie" of req.headers
+                    cookiestr = escape(s.session_key) + '='
+                    s.timeout = 0
+            else
+                cookiestr = escape(s.session_key) + '=' + escape(exports.serialize(s.secret, req.session))
+
+            if cookiestr
+                if s.useExpires  then cookiestr += '; expires=' + exports.expires(s.timeout)
+                if s.useMaxAge   then cookiestr += '; max-age=' + (s.timeout / 1000) # In seconds
+                if s.path        then cookiestr += '; path=' + s.path
+                if s.domain      then cookiestr += '; domain=' + s.domain
+                if s.secure      then cookiestr += '; secure'
+                if s.useHttpOnly then cookiestr += '; HttpOnly'
+
+                if Array.isArray(headers)
+                    headers.push ['Set-Cookie', cookiestr]
+                else
+                    # if a Set-Cookie header already exists, convert headers to
+                    # array so we can send multiple Set-Cookie headers.
+                    if headers['Set-Cookie']
+                        headers = exports.headersToArray(headers)
+                        headers.push ['Set-Cookie', cookiestr]
+                    else
+                        # if no Set-Cookie header exists, leave the headers as an
+                        # object, and add a Set-Cookie property
+                        headers['Set-Cookie'] = cookiestr
+
+
+            args = [statusCode, reasonPhrase, headers]
+            # get rid of reasonPhrase if not defined
+            if not args[1]
+                args.splice(1, 1)
+
+            # call the original writeHead on the request
+            return _writeHead.apply res, args
+
+        next()
+
+
+
+# max allowable length of a cookie (4KB)
+exports.MAX_LENGTH = 4096
+
+
+
+# read session from given request cookie
+exports.readSession = (session_key, secret, timeout, req) =>
+    # Reads the session data stored in the cookie named 'key' if it validates,
+    # otherwise returns an empty object.
+    cookies = exports.readCookies(req)
+    if session_key of cookies and cookies[session_key]
+        return exports.deserialize(secret, timeout, cookies[session_key])
+    else
+        return undefined;
+
+
+# read cookies from request object
+exports.readCookies = (req) ->
+    # if "cookieDecoder" is in use, then req.cookies
+    # will already contain the parsed cookies
+    if req.cookies
+        return req.cookies
+    else
+        # Extracts the cookies from a request object.
+        cookie = req.headers.cookie
+        return {} if not cookie
+
+        parts = cookie.split(/\s*;\s*/g).map (x) ->
+            x.split('=')
+
+        func = (a, x) ->
+            a[unescape(x[0])] = unescape(x[1])
+            a
+
+        parts.reduce(func, {})
+
+
+
+# convert key-value headers into arrays
+exports.headersToArray = (headers) ->
+    return headers if Array.isArray(headers)
+    func = (arr, k) ->
+        arr.push [k, headers[k]]
+        arr
+    Object.keys(headers).reduce(func, [])
+
+
+# parse cookie data
+exports.deserialize = (secret, timeout, str) =>
+    # Parses a secure cookie string, returning the object stored within it.
+    # Throws an exception if the secure cookie string does not validate.
+    if not exports.valid(secret, timeout, str)
+        error = new Error('invalid cookie')
+        error.type = 'InvalidCookieError'
+        throw error
+    JSON.parse(exports.decrypt(secret, exports.split(str).data_blob))
+
+
+# construct cookie data
+exports.serialize = (secret, data) =>
+    # Turns a JSON-compatibile object literal into a secure cookie string
+    data_str = JSON.stringify(data)
+    data_enc = exports.encrypt(secret, data_str)
+    timestamp = new Date().getTime()
+    hmac_sig = exports.hmac_signature(secret, timestamp, data_enc)
+    result = hmac_sig + timestamp + data_enc;
+    if not exports.checkLength(result)
+        throw new Error 'data too long to store in a cookie'
+    result;
+
+
+exports.split = (str) ->
+    # Splits a cookie string into hmac signature, timestamp and data blob.
+    return {
+        hmac_signature: str.slice(0,40)
+        timestamp: parseInt(str.slice(40, 53), 10)
+        data_blob: str.slice(53)
+    }
+
+
+# calculate hmac signature
+exports.hmac_signature = (secret, timestamp, data) ->
+    # Generates a HMAC for the timestamped data, returning the
+    # hex digest for the signature.
+    hmac = crypto.createHmac('sha1', secret)
+    hmac.update(timestamp + data);
+    hmac.digest('hex')
+
+
+exports.valid = (secret, timeout, str) =>
+    # Tests the validity of a cookie string. Returns true if the HMAC
+    # signature of the secret, timestamp and data blob matches the HMAC in the
+    # cookie string, and the cookie's age is less than the timeout value.
+    parts = exports.split(str)
+    hmac_sig = exports.hmac_signature secret, parts.timestamp, parts.data_blob
+    return parts.hmac_signature is hmac_sig and
+        new Date().getTime() < (parts.timestamp + timeout)
+
+
+exports.decrypt = (secret, str) ->
+    # Decrypt the aes192 encoded str
+    decipher = crypto.createDecipher("aes192", secret)
+    decipher.update(str, 'hex', 'utf8') + decipher.final('utf8')
+
+
+exports.encrypt = (secret, str) ->
+    # Encrypt the str with aes192 using secret.
+    cipher = crypto.createCipher("aes192", secret)
+    cipher.update(str, 'utf8', 'hex') + cipher.final('hex')
+
+
+exports.checkLength = (str) ->
+    # Test if a string is within the maximum length allowed for a cookie (4KB.
+    return str.length <= exports.MAX_LENGTH
+
+
+# Generates an expires date
+# exports.params timeout the time in milliseconds before the cookie expires
+exports.expires = (timeout) ->
+    new Date(new Date().getTime() + timeout).toUTCString();

--- a/src/cookie-sessions.coffee
+++ b/src/cookie-sessions.coffee
@@ -43,7 +43,7 @@ exports = module.exports = (settings) ->
 
 
     # Handle a request - the main method!
-    return (req, res, next) =>
+    return (req, res, next) ->
         # if the request is not under the specified path, do nothing.
         if 0 isnt url.parse(req.url).pathname.indexOf(s.path)
             return next()
@@ -117,7 +117,7 @@ exports = module.exports = (settings) ->
 
 # read session from given request cookie
 # @return undefined if session data wasn't found or couldn't be read
-exports.readSession = (session_key, secret, timeout, req) =>
+exports.readSession = (session_key, secret, timeout, req) ->
     # Reads the session data stored in the cookie named 'key' if it validates,
     # otherwise returns an empty object.
     cookies = exports.readCookies(req)
@@ -160,7 +160,7 @@ exports.headersToArray = (headers) ->
 
 # parse cookie data
 # @return undefined if data couldn't be parsed
-exports.deserialize = (secret, timeout, str) =>
+exports.deserialize = (secret, timeout, str) ->
     # Parses a secure cookie string, returning the object stored within it.
     # Returns undefined (and sends out an error) if the secure cookie string does not validate.
     if not exports.valid(secret, timeout, str)
@@ -172,7 +172,7 @@ exports.deserialize = (secret, timeout, str) =>
 
 # construct cookie data
 # @return undefined if data couldn't be constructed
-exports.serialize = (secret, data) =>
+exports.serialize = (secret, data) ->
     # Turns a JSON-compatibile object literal into a secure cookie string
     data_str = JSON.stringify(data)
     data_enc = exports.encrypt(secret, data_str)
@@ -202,7 +202,7 @@ exports.hmac_signature = (secret, timestamp, data) ->
     hmac.digest('hex')
 
 
-exports.valid = (secret, timeout, str) =>
+exports.valid = (secret, timeout, str) ->
     # Tests the validity of a cookie string. Returns true if the HMAC
     # signature of the secret, timestamp and data blob matches the HMAC in the
     # cookie string, and the cookie's age is less than the timeout value.

--- a/src/cookie-sessions.coffee
+++ b/src/cookie-sessions.coffee
@@ -1,6 +1,9 @@
 crypto = require('crypto')
 url = require('url')
 
+# max allowable length of a cookie (4KB)
+MAX_LENGTH = 4096
+
 
 exports = module.exports = (settings) ->
     s =
@@ -110,9 +113,6 @@ exports = module.exports = (settings) ->
         next()
 
 
-
-# max allowable length of a cookie (4KB)
-exports.MAX_LENGTH = 4096
 
 
 # read session from given request cookie
@@ -226,7 +226,7 @@ exports.encrypt = (secret, str) ->
 
 exports.checkLength = (str) ->
     # Test if a string is within the maximum length allowed for a cookie (4KB.
-    return str.length <= exports.MAX_LENGTH
+    return str.length <= MAX_LENGTH
 
 
 # Generates an expires date

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ require.paths.push(__dirname + '/deps');
 require.paths.push(__dirname + '/lib');
 
 try {
-    var testrunner = require('nodeunit').testrunner;
+    var testrunner = require('nodeunit').reporters.default;
 }
 catch(e) {
     var sys = require('sys');

--- a/test.js
+++ b/test.js
@@ -1,11 +1,9 @@
 #!/usr/local/bin/node
 
-require.paths.push(__dirname);
-require.paths.push(__dirname + '/deps');
-require.paths.push(__dirname + '/lib');
+var nodeunit = require('./deps/nodeunit');
 
 try {
-    var testrunner = require('nodeunit').reporters.default;
+    var testrunner = nodeunit.reporters.default;
 }
 catch(e) {
     var sys = require('sys');

--- a/test/test-cookie-sessions.js
+++ b/test/test-cookie-sessions.js
@@ -319,14 +319,14 @@ exports['onRequest'] = function(test){
     var s = {
         session_key:'_node',
         secret: 'secret',
-        timeout: 86400
+        timeout: 86400000
     };
     var req = {url: '/'};
 
     sessions.readSession = function(key, secret, timeout, req){
         test.equals(key, '_node', 'readSession called with session key');
         test.equals(secret, 'secret', 'readSession called with secret');
-        test.equals(timeout, 86400, 'readSession called with timeout');
+        test.equals(timeout, 86400000, 'readSession called with timeout');
         return 'testsession';
     };
     var next = function(){
@@ -348,7 +348,7 @@ exports['writeHead'] = function(test){
     var s = {
         session_key:'_node',
         secret: 'secret',
-        timeout: 86400
+        timeout: 86400000
     };
     var req = {headers: {cookie: "_node="}, url: '/'};
     var res = {
@@ -395,7 +395,7 @@ exports['writeHead doesnt write cookie if none exists and session is undefined']
     var s = {
         session_key:'_node',
         secret: 'secret',
-        timeout: 86400
+        timeout: 86400000
     };
     var req = {headers: {}, url: '/'};
     var res = {
@@ -420,7 +420,7 @@ exports['writeHead writes empty cookie with immediate expiration if session is u
     var s = {
         session_key:'_node',
         secret: 'secret',
-        timeout: 86400
+        timeout: 86400000
     };
     var req = {headers: {cookie: "_node=Blah"}, url: '/'};
     var res = {
@@ -490,7 +490,7 @@ exports['set multiple cookies'] = function(test){
 
     var _expires = sessions.expires;
     sessions.expires = function(timeout){
-        test.equals(timeout, 12345);
+        test.equals(timeout, 12345000);
         return 'expiry_date';
     };
 
@@ -510,7 +510,7 @@ exports['set multiple cookies'] = function(test){
         test.done();
     }};
 
-    sessions({secret: 'secret', timeout: 12345})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, {
             'other_header': 'val',
@@ -528,7 +528,7 @@ exports['set single cookie'] = function(test){
 
     var _expires = sessions.expires;
     sessions.expires = function(timeout){
-        test.equals(timeout, 12345);
+        test.equals(timeout, 12345000);
         return 'expiry_date';
     };
 
@@ -546,7 +546,7 @@ exports['set single cookie'] = function(test){
         sessions.expires = _expires;
         test.done();
     }};
-    sessions({secret: 'secret', timeout: 12345})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, {'other_header': 'val'});
     });
@@ -561,7 +561,7 @@ exports['handle headers as array'] = function(test){
 
     var _expires = sessions.expires;
     sessions.expires = function(timeout){
-        test.equals(timeout, 12345);
+        test.equals(timeout, 12345000);
         return 'expiry_date';
     };
 
@@ -579,7 +579,7 @@ exports['handle headers as array'] = function(test){
         sessions.serialize = _serialize;
         test.done();
     }};
-    sessions({secret: 'secret', timeout: 12345})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, [['header1', 'val1'],['header2', 'val2']]);
     });
@@ -607,7 +607,7 @@ exports['send cookies even if there are no headers'] = function (test) {
             test.done();
         }
     };
-    sessions({secret: 'secret', timeout: 12345})(req, res, function () {
+    sessions({secret: 'secret', timeout: 12345000})(req, res, function () {
         req.session = {test: 'test'};
         res.writeHead(200);
     });
@@ -624,7 +624,7 @@ exports['send cookies when no headers but reason_phrase'] = function (test) {
             test.done();
         }
     };
-    sessions({secret: 'secret', timeout: 12345})(req, res, function () {
+    sessions({secret: 'secret', timeout: 12345000})(req, res, function () {
         req.session = {test: 'test'};
         res.writeHead(200, 'reason');
     });
@@ -642,7 +642,7 @@ exports['custom path'] = function (test) {
     };
     sessions({
         secret: 'secret',
-        timeout: 12345,
+        timeout: 12345000,
         path: '/test/path'
     })(req, res, function () {
         req.session = {test: 'test'};
@@ -662,7 +662,7 @@ exports['don\'t set cookie if incorrect path'] = function (test) {
     };
     sessions({
         secret: 'secret',
-        timeout: 12345,
+        timeout: 12345000,
         path: '/test/path'
     })(req, res, function () {
         req.session = {test: 'test'};
@@ -727,7 +727,7 @@ exports['useExpires: false'] = function(test){
         sessions.serialize = _serialize;
         test.done();
     }};
-    sessions({secret: 'secret', timeout: 12345, useExpires: false})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000, useExpires: false})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, {'other_header': 'val'});
     });
@@ -742,7 +742,7 @@ exports['useMaxAge: false'] = function(test){
 
     var _expires = sessions.expires;
     sessions.expires = function(timeout){
-        test.equals(timeout, 12345);
+        test.equals(timeout, 12345000);
         return 'expiry_date';
     };
     var req = {headers: {cookie:''}, url: '/'};
@@ -758,7 +758,7 @@ exports['useMaxAge: false'] = function(test){
         sessions.expires = _expires;
         test.done();
     }};
-    sessions({secret: 'secret', timeout: 12345, useMaxAge: false})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000, useMaxAge: false})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, {'other_header': 'val'});
     });
@@ -773,7 +773,7 @@ exports['useHttpOnly: false'] = function(test){
 
     var _expires = sessions.expires;
     sessions.expires = function(timeout){
-        test.equals(timeout, 12345);
+        test.equals(timeout, 12345000);
         return 'expiry_date';
     };
     var req = {headers: {cookie:''}, url: '/'};
@@ -790,7 +790,7 @@ exports['useHttpOnly: false'] = function(test){
         sessions.expires = _expires;
         test.done();
     }};
-    sessions({secret: 'secret', timeout: 12345, useHttpOnly: false})(req, res, function(){
+    sessions({secret: 'secret', timeout: 12345000, useHttpOnly: false})(req, res, function(){
         req.session = {test: 'test'};
         res.writeHead(200, {'other_header': 'val'});
     });

--- a/test/test-cookie-sessions.js
+++ b/test/test-cookie-sessions.js
@@ -1,4 +1,4 @@
-var sessions = require('cookie-sessions');
+var sessions = require('../lib/cookie-sessions');
 
 
 exports['split'] = function(test){


### PR DESCRIPTION
I started off by merging publickeating's excellent work (https://github.com/caolan/cookie-sessions/pull/14) and then went onto rewrite the code in CoffeeScript - the code easier to read and it makes it easier to ensure generated code is JSLint compliant. A Cakefile is included to generate the `lib/cookie-sessions.js` file. I ran all the tests to make sure everything still works as expected.

I then added an _onError_ setting. By default it's null, in which case Errors are thrown as normal. If a function is provided then that function is called instead with the Error object representing the error. Tests have been added for using onError with all existing error messages.

Example for onError:

```
    sessions({
        ...
        onError: function(err) {
            // e.g. err.toString() -> "Error: Invalid cookie"
        }
    });
```
