### PR TITLE
Shouldn't readSession return an empty object {} (as the comment on the t...

### DIFF
--- a/lib/cookie-sessions.js
+++ b/lib/cookie-sessions.js
@@ -210,7 +210,7 @@ exports.readSession = function(key, secret, timeout, req){
     if(cookies[key]){
         return exports.deserialize(secret, timeout, cookies[key]);
     }
-    return undefined;
+    return {};
 };
 
 


### PR DESCRIPTION
...op of the function says), instead of undefined if the cookie is not present?

Some middlewares that rely on the session (like everyauth) complain that it is undefined. Does this change have some security implications?
